### PR TITLE
Fix wrong name reference in tutorial code

### DIFF
--- a/week-1.md
+++ b/week-1.md
@@ -228,7 +228,7 @@ and copy-paste the complete following document into it.
 
 ###
 ### Hi students! Please don’t change this file,
-### run it with `sh check.sh` instead.
+### run it with `sh tutorial.sh` instead.
 ###
 
 function bold {


### PR DESCRIPTION
The code mentioned running `sh check.sh`, while all other copy calls it `tutorial.sh`